### PR TITLE
Add unit tests for NewsService and NewsController

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,4 +43,5 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-devtools")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
+	testImplementation("io.mockk:mockk:1.13.13")
 }

--- a/src/test/kotlin/ru/yzuykov/springmvcdemo/controller/NewsControllerTest.kt
+++ b/src/test/kotlin/ru/yzuykov/springmvcdemo/controller/NewsControllerTest.kt
@@ -1,0 +1,86 @@
+package ru.yzuykov.springmvcdemo.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ui.Model
+import ru.yzuykov.springmvcdemo.model.ArticleDto
+import ru.yzuykov.springmvcdemo.model.SourceDto
+import ru.yzuykov.springmvcdemo.service.api.NewsService
+import java.util.Date
+
+class NewsControllerTest {
+
+    private val newsService: NewsService = mockk()
+    private lateinit var controller: NewsController
+
+    @BeforeEach
+    fun setUp() {
+        controller = NewsController(newsService)
+    }
+
+    @Test
+    fun `welcome returns welcome view with name attribute`() {
+        // given
+        val model: Model = mockk(relaxed = true)
+
+        // when
+        val result = controller.welcome(model)
+
+        // then
+        assertEquals("welcome", result)
+        io.mockk.verify { model.addAttribute("Name", "Yuriy") }
+    }
+
+    @Test
+    fun `news returns news view with articles list`() {
+        // given
+        val articles = listOf(
+            ArticleDto(
+                source = SourceDto("source-1", "Test Source"),
+                author = "Author 1",
+                title = "Article 1",
+                description = "Description 1",
+                url = "https://test.com/article1",
+                urlToImage = "https://test.com/image1.jpg",
+                publishedAt = Date()
+            ),
+            ArticleDto(
+                source = SourceDto("source-2", "Test Source 2"),
+                author = "Author 2",
+                title = "Article 2",
+                description = "Description 2",
+                url = "https://test.com/article2",
+                urlToImage = "https://test.com/image2.jpg",
+                publishedAt = Date()
+            )
+        )
+        val model: Model = mockk(relaxed = true)
+
+        every { newsService.getArticlesList() } returns articles
+
+        // when
+        val result = controller.news(model)
+
+        // then
+        assertEquals("news", result)
+        io.mockk.verify { model.addAttribute("NewsList", articles) }
+    }
+
+    @Test
+    fun `news passes empty list when service returns no articles`() {
+        // given
+        val model: Model = mockk(relaxed = true)
+        every { newsService.getArticlesList() } returns emptyList()
+
+        // when
+        val result = controller.news(model)
+
+        // then
+        assertEquals("news", result)
+        io.mockk.verify { model.addAttribute("NewsList", emptyList<ArticleDto>()) }
+    }
+}

--- a/src/test/kotlin/ru/yzuykov/springmvcdemo/service/impl/NewsServiceImplTest.kt
+++ b/src/test/kotlin/ru/yzuykov/springmvcdemo/service/impl/NewsServiceImplTest.kt
@@ -1,0 +1,111 @@
+package ru.yzuykov.springmvcdemo.service.impl
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import ru.yzuykov.springmvcdemo.client.NewsClient
+import ru.yzuykov.springmvcdemo.config.NewsProperties
+import ru.yzuykov.springmvcdemo.model.ArticleDto
+import ru.yzuykov.springmvcdemo.model.NewsResponse
+import ru.yzuykov.springmvcdemo.model.SourceDto
+import java.util.Date
+
+class NewsServiceImplTest {
+
+    private val newsClient: NewsClient = mockk()
+    private val newsProperties: NewsProperties = mockk()
+    private val newsService = NewsServiceImpl(newsClient, newsProperties)
+
+    @Test
+    fun `getArticlesList returns articles when client returns data`() {
+        // given
+        val apiKey = "test-api-key"
+        val sources = "test-sources"
+        val articles = listOf(
+            ArticleDto(
+                source = SourceDto("source-1", "Test Source"),
+                author = "Test Author",
+                title = "Test Article",
+                description = "Test Description",
+                url = "https://test.com/article",
+                urlToImage = "https://test.com/image.jpg",
+                publishedAt = Date()
+            )
+        )
+        val newsResponse = NewsResponse(
+            status = "ok",
+            totalResults = 1,
+            articles = articles
+        )
+
+        every { newsProperties.apiKey } returns apiKey
+        every { newsProperties.sources } returns sources
+        every { newsClient.getTopHeadLines(apiKey, sources) } returns newsResponse
+
+        // when
+        val result = newsService.getArticlesList()
+
+        // then
+        assertEquals(1, result.size)
+        assertEquals("Test Article", result[0].title)
+        assertEquals("Test Author", result[0].author)
+    }
+
+    @Test
+    fun `getArticlesList returns empty list when client returns null`() {
+        // given
+        val apiKey = "test-api-key"
+        val sources = "test-sources"
+
+        every { newsProperties.apiKey } returns apiKey
+        every { newsProperties.sources } returns sources
+        every { newsClient.getTopHeadLines(apiKey, sources) } returns null
+
+        // when
+        val result = newsService.getArticlesList()
+
+        // then
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getArticlesList returns empty list when articles list is empty`() {
+        // given
+        val apiKey = "test-api-key"
+        val sources = "test-sources"
+        val newsResponse = NewsResponse(
+            status = "ok",
+            totalResults = 0,
+            articles = emptyList()
+        )
+
+        every { newsProperties.apiKey } returns apiKey
+        every { newsProperties.sources } returns sources
+        every { newsClient.getTopHeadLines(apiKey, sources) } returns newsResponse
+
+        // when
+        val result = newsService.getArticlesList()
+
+        // then
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getArticlesList passes correct API key and sources to client`() {
+        // given
+        val apiKey = "my-api-key"
+        val sources = "bbc-news,cnn"
+
+        every { newsProperties.apiKey } returns apiKey
+        every { newsProperties.sources } returns sources
+        every { newsClient.getTopHeadLines(apiKey, sources) } returns null
+
+        // when
+        newsService.getArticlesList()
+
+        // then - verify the correct parameters were passed
+        io.mockk.verify { newsClient.getTopHeadLines(apiKey, sources) }
+    }
+}


### PR DESCRIPTION
## Summary

Added comprehensive unit tests for service and controller layers.

## Test Coverage

### NewsServiceImplTest (4 tests)
- ✅ Returns articles when client returns data
- ✅ Returns empty list when client returns null
- ✅ Returns empty list when articles list is empty
- ✅ Verifies correct API key and sources are passed to client

### NewsControllerTest (3 tests)
- ✅ Welcome returns correct view and model attribute
- ✅ News returns correct view with articles list
- ✅ News handles empty list correctly

## Changes
- Added  with MockK mocking
- Added  with MockK mocking
- Added MockK dependency (v1.13.13) to build.gradle.kts