### PR TITLE
Fix critical security and configuration issues (round 2)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 	// Spring Boot starters
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-devtools")
 
 	// Spring Cloud

--- a/src/main/kotlin/ru/yzuykov/springmvcdemo/client/NewsClient.kt
+++ b/src/main/kotlin/ru/yzuykov/springmvcdemo/client/NewsClient.kt
@@ -2,6 +2,7 @@ package ru.yzuykov.springmvcdemo.client
 
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import ru.yzuykov.springmvcdemo.model.NewsResponse
 
@@ -10,7 +11,7 @@ interface NewsClient {
 
     @GetMapping("/top-headlines")
     fun getTopHeadLines(
-        @RequestParam(value = "apiKey") apiKey: String,
-        @RequestParam(value = "sources") sources: String
-    ): NewsResponse?
+        @RequestHeader("X-Api-Key") apiKey: String,
+        @RequestParam("sources") sources: String
+    ): NewsResponse
 }

--- a/src/main/kotlin/ru/yzuykov/springmvcdemo/config/NewsProperties.kt
+++ b/src/main/kotlin/ru/yzuykov/springmvcdemo/config/NewsProperties.kt
@@ -1,8 +1,13 @@
 package ru.yzuykov.springmvcdemo.config
 
+import jakarta.validation.constraints.NotBlank
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 
+@Validated
 @ConfigurationProperties(prefix = "news")
-data class NewsProperties(var apiKey: String = "",
-                          var sources: String = "",
-                          var url: String = "")
+data class NewsProperties(
+    @field:NotBlank val apiKey: String = "",
+    @field:NotBlank val sources: String = "",
+    @field:NotBlank val url: String = ""
+)

--- a/src/main/kotlin/ru/yzuykov/springmvcdemo/controller/NewsController.kt
+++ b/src/main/kotlin/ru/yzuykov/springmvcdemo/controller/NewsController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import ru.yzuykov.springmvcdemo.service.api.NewsService
 
 @Controller
-class NewsController @Autowired constructor(val newsService: NewsService) {
+class NewsController(private val newsService: NewsService) {
 
     @GetMapping("/")
     fun welcome(model: Model): String {

--- a/src/main/kotlin/ru/yzuykov/springmvcdemo/service/impl/NewsServiceImpl.kt
+++ b/src/main/kotlin/ru/yzuykov/springmvcdemo/service/impl/NewsServiceImpl.kt
@@ -1,6 +1,6 @@
 package ru.yzuykov.springmvcdemo.service.impl
 
-import org.springframework.beans.factory.annotation.Autowired
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import ru.yzuykov.springmvcdemo.client.NewsClient
 import ru.yzuykov.springmvcdemo.config.NewsProperties
@@ -8,9 +8,19 @@ import ru.yzuykov.springmvcdemo.model.ArticleDto
 import ru.yzuykov.springmvcdemo.service.api.NewsService
 
 @Service
-class NewsServiceImpl @Autowired constructor(val newsClient: NewsClient, val newsProperties: NewsProperties) : NewsService {
+class NewsServiceImpl(
+    private val newsClient: NewsClient,
+    private val newsProperties: NewsProperties
+) : NewsService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     override fun getArticlesList(): List<ArticleDto> {
-        return newsClient.getTopHeadLines(newsProperties.apiKey, newsProperties.sources)?.articles ?: listOf()
+        return try {
+            newsClient.getTopHeadLines(newsProperties.apiKey, newsProperties.sources).articles
+        } catch (e: Exception) {
+            log.error("Failed to fetch news from NewsAPI", e)
+            emptyList()
+        }
     }
 }

--- a/src/test/kotlin/ru/yzuykov/springmvcdemo/SpringmvcdemoApplicationTests.kt
+++ b/src/test/kotlin/ru/yzuykov/springmvcdemo/SpringmvcdemoApplicationTests.kt
@@ -2,8 +2,10 @@ package ru.yzuykov.springmvcdemo
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
 
 @SpringBootTest
+@TestPropertySource(properties = ["news.api-key=test-key", "news.sources=test-sources", "news.url=https://test.com"])
 class SpringmvcdemoApplicationTests {
 
 	@Test

--- a/src/test/kotlin/ru/yzuykov/springmvcdemo/controller/NewsControllerTest.kt
+++ b/src/test/kotlin/ru/yzuykov/springmvcdemo/controller/NewsControllerTest.kt
@@ -3,7 +3,6 @@ package ru.yzuykov.springmvcdemo.controller
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.ui.Model

--- a/src/test/kotlin/ru/yzuykov/springmvcdemo/service/impl/NewsServiceImplTest.kt
+++ b/src/test/kotlin/ru/yzuykov/springmvcdemo/service/impl/NewsServiceImplTest.kt
@@ -15,14 +15,16 @@ import java.time.Instant
 class NewsServiceImplTest {
 
     private val newsClient: NewsClient = mockk()
-    private val newsProperties: NewsProperties = mockk()
+    private val newsProperties = NewsProperties(
+        apiKey = "test-api-key",
+        sources = "test-sources",
+        url = "https://test.com"
+    )
     private val newsService = NewsServiceImpl(newsClient, newsProperties)
 
     @Test
     fun `getArticlesList returns articles when client returns data`() {
         // given
-        val apiKey = "test-api-key"
-        val sources = "test-sources"
         val articles = listOf(
             ArticleDto(
                 source = SourceDto("source-1", "Test Source"),
@@ -40,9 +42,7 @@ class NewsServiceImplTest {
             articles = articles
         )
 
-        every { newsProperties.apiKey } returns apiKey
-        every { newsProperties.sources } returns sources
-        every { newsClient.getTopHeadLines(apiKey, sources) } returns newsResponse
+        every { newsClient.getTopHeadLines(newsProperties.apiKey, newsProperties.sources) } returns newsResponse
 
         // when
         val result = newsService.getArticlesList()
@@ -54,14 +54,9 @@ class NewsServiceImplTest {
     }
 
     @Test
-    fun `getArticlesList returns empty list when client returns null`() {
+    fun `getArticlesList returns empty list when client throws exception`() {
         // given
-        val apiKey = "test-api-key"
-        val sources = "test-sources"
-
-        every { newsProperties.apiKey } returns apiKey
-        every { newsProperties.sources } returns sources
-        every { newsClient.getTopHeadLines(apiKey, sources) } returns null
+        every { newsClient.getTopHeadLines(newsProperties.apiKey, newsProperties.sources) } throws RuntimeException("API error")
 
         // when
         val result = newsService.getArticlesList()
@@ -73,17 +68,13 @@ class NewsServiceImplTest {
     @Test
     fun `getArticlesList returns empty list when articles list is empty`() {
         // given
-        val apiKey = "test-api-key"
-        val sources = "test-sources"
         val newsResponse = NewsResponse(
             status = "ok",
             totalResults = 0,
             articles = emptyList()
         )
 
-        every { newsProperties.apiKey } returns apiKey
-        every { newsProperties.sources } returns sources
-        every { newsClient.getTopHeadLines(apiKey, sources) } returns newsResponse
+        every { newsClient.getTopHeadLines(newsProperties.apiKey, newsProperties.sources) } returns newsResponse
 
         // when
         val result = newsService.getArticlesList()
@@ -95,17 +86,18 @@ class NewsServiceImplTest {
     @Test
     fun `getArticlesList passes correct API key and sources to client`() {
         // given
-        val apiKey = "my-api-key"
-        val sources = "bbc-news,cnn"
+        val newsResponse = NewsResponse(
+            status = "ok",
+            totalResults = 0,
+            articles = emptyList()
+        )
 
-        every { newsProperties.apiKey } returns apiKey
-        every { newsProperties.sources } returns sources
-        every { newsClient.getTopHeadLines(apiKey, sources) } returns null
+        every { newsClient.getTopHeadLines(newsProperties.apiKey, newsProperties.sources) } returns newsResponse
 
         // when
         newsService.getArticlesList()
 
         // then - verify the correct parameters were passed
-        io.mockk.verify { newsClient.getTopHeadLines(apiKey, sources) }
+        io.mockk.verify { newsClient.getTopHeadLines(newsProperties.apiKey, newsProperties.sources) }
     }
 }


### PR DESCRIPTION
## Summary

Second round of fixes from code review findings:

### Security
- Moved API-key from URL query parameter to `X-Api-Key` HTTP header — prevents key exposure in logs, metrics, and tracing systems
- Changed Feign client from `@RequestParam` to `@RequestHeader`

### Configuration Validation
- Added `@Validated` + `@field:NotBlank` to `NewsProperties` — application fails fast with clear error message if required config is missing
- Added `spring-boot-starter-validation` dependency
- Added `@TestPropertySource` to `SpringmvcdemoApplicationTests` with test config values

### Code Quality
- Removed unnecessary `@Autowired` from single-constructor classes
- Changed `val` to `private val` for proper encapsulation
- Added error logging in `NewsServiceImpl`
- Replaced mocked `NewsProperties` with real instances in tests
- Removed unused import from `NewsControllerTest`

### API Contract
- Changed `NewsClient.getTopHeadLines()` return type from `NewsResponse?` to `NewsResponse` — Feign throws on errors, null check not needed
- Simplified `NewsServiceImpl.getArticlesList()` with try/catch and logging

All tests pass. Build successful.