### PR TITLE
refactor: replace bootstrap with custom CSS, add grid/cards/utilities, fix a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@
 
 ## Описание
 
-Приложение для отображения новостных заголовков через внешний API ([NewsAPI](https://newsapi.org/)). Пользователь может перейти на страницу новостей, где приложение через Feign-клиент загружает актуальные статьи из указанных источников.
+Приложение для отображения новостных заголовков через внешний API ([NewsAPI](https://newsapi.org/)). На странице новостей через декларативный HTTP-клиент (`@HttpExchange`) загружаются доступные источники и актуальные статьи.
 
 ### Возможности
 
-- Отображение приветственной страницы
-- Загрузка и отображение списка новостей через NewsAPI
-- Интеграция с внешним REST API через Spring Cloud OpenFeign
-- Шаблонизация через Thymeleaf с Bootstrap-стилизацией
+- Приветственная страница
+- Загрузка и отображение новостей через NewsAPI
+- Динамическая загрузка списка источников (по языку)
+- Интеграция с внешним REST API через `@HttpExchange` (Spring Framework 7)
+- Шаблонизация через Thymeleaf с кастомными CSS-стилями
+- Дизайн-токены, CSS Grid, адаптивная вёрстка
 - Автоматическая перезагрузка при разработке (Spring Boot DevTools)
 
 ## Стек технологий
@@ -20,27 +22,23 @@
 |------------|--------|
 | Java | 21 |
 | Kotlin | 2.1.10 |
-| Spring Boot | 3.5.5 |
-| Spring Cloud | 2025.0.0 |
+| Spring Boot | 4.0.1 |
+| Spring Framework | 7.0.2 |
 | Gradle | 8.12 |
 | Thymeleaf | — |
-| Bootstrap | 5.1.3 |
-| Spring Cloud OpenFeign | — |
 | Jackson (Kotlin) | — |
-| Webjars | — |
 
 ### Тестирование
 
 | Библиотека | Версия |
 |------------|--------|
 | JUnit 5 | — |
-| Spring Boot Test | — |
 | MockK | 1.13.13 |
 
 ## Запуск
 
 ```bash
-./gradlew bootRun
+NEWS_API_KEY=your-api-key ./gradlew bootRun
 ```
 
 После запуска приложение доступно по адресу: [http://localhost:8080](http://localhost:8080)
@@ -49,13 +47,13 @@
 
 ```
 src/main/kotlin/ru/yzuykov/springmvcdemo/
-├── controller/        # Контроллеры (NewsController)
-├── service/           # Сервисный слой
-│   ├── api/           # Интерфейсы сервисов
-│   └── impl/          # Реализации сервисов
-├── client/            # Feign-клиенты для внешних API
-├── config/            # Конфигурация приложения
-└── model/             # DTO и модели данных
+├── controller/        # NewsController: `/`, `/news`
+├── service/
+│   ├── api/           # NewsService interface
+│   └── impl/          # NewsServiceImpl
+├── client/            # NewsHttpClient (@HttpExchange)
+├── config/            # NewsProperties
+└── model/             # DTO
 ```
 
 ## Конфигурация
@@ -64,10 +62,10 @@ src/main/kotlin/ru/yzuykov/springmvcdemo/
 
 ```yaml
 news:
-  url: "https://newsapi.org/v2"
-  apiKey: "your-api-key"
-  sources: "google-news-ru"
+  apiKey: ${NEWS_API_KEY:demo}
 ```
+
+Ключ передаётся через переменную окружения `NEWS_API_KEY`.
 
 ## Тесты
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,6 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-	// Webjars
-	implementation("org.webjars:webjars-locator:0.52")
-	implementation("org.webjars.npm:bootstrap:5.3.3")
-
 	// Test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")

--- a/docs/superpowers/plans/2026-05-22-bootstrap-to-native-css.md
+++ b/docs/superpowers/plans/2026-05-22-bootstrap-to-native-css.md
@@ -1,0 +1,392 @@
+# Bootstrap → Native CSS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Bootstrap 5.3.3 (WebJars) and replace with ~120 lines of custom CSS using CSS variables and component classes.
+
+**Architecture:** One CSS file with design tokens (`:root`), component classes (`.navbar`, `.news-card`), and minimal utilities. Three Thymeleaf templates updated to use new classes. Bootstrap JS replaced by checkbox hack for navbar collapse.
+
+**Tech Stack:** CSS (no frameworks), HTML/Thymeleaf, Gradle (WebJars removal)
+
+---
+
+### Task 1: Create CSS file, update build config, connect CSS to templates
+
+**Files:**
+- Create: `src/main/resources/static/css/style.css`
+- Modify: `build.gradle.kts:32-34`
+- Modify: `src/main/resources/templates/fragments/header.html:4-8`
+
+- [ ] **Step 1: Create `style.css` with design tokens**
+
+```css
+:root {
+  --color-primary: #0d6efd;
+  --color-secondary: #20c997;
+  --color-dark: #212529;
+  --color-muted: #6c757d;
+  --color-secondary-text: #6c757d;
+  --color-body-bg: #fff;
+  --color-card-bg: #fff;
+  --color-border: rgba(0, 0, 0, 0.125);
+  --navbar-gradient: linear-gradient(90deg, #0d6efd, #20c997);
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 3rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --radius: 0.375rem;
+  --container-max-width: 1140px;
+  --breakpoint-md: 768px;
+}
+```
+
+- [ ] **Step 2: Remove Bootstrap WebJars from `build.gradle.kts`**
+
+Remove these lines:
+```kotlin
+// Webjars
+implementation("org.webjars:webjars-locator:0.52")
+implementation("org.webjars.npm:bootstrap:5.3.3")
+```
+
+- [ ] **Step 3: Update `header.html` — replace Bootstrap links with custom CSS**
+
+In `header.html`, in the `header-css` fragment, replace the Bootstrap CSS `<link>` and JS `<script>` with:
+```html
+<link rel="stylesheet" type="text/css" th:href="@{/css/style.css}" />
+```
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `./gradlew build`
+
+---
+
+### Task 2: Rewrite navbar (checkbox hack, custom CSS)
+
+**Files:**
+- Modify: `src/main/resources/templates/fragments/header.html` (navbar)
+- Modify: `src/main/resources/static/css/style.css` (append navbar CSS)
+
+- [ ] **Step 1: Add navbar + reset CSS to `style.css`**
+
+Append to `style.css`:
+```css
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: var(--font-size-base);
+  color: var(--color-dark);
+  background: var(--color-body-bg);
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Navbar */
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--navbar-gradient);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.navbar-brand {
+  color: #fff;
+  font-size: var(--spacing-lg);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.navbar-brand:hover {
+  text-decoration: none;
+  opacity: 0.9;
+}
+
+.nav-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: none;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--navbar-gradient);
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.nav-toggle:checked ~ .nav-links {
+  display: flex;
+}
+
+.nav-link {
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  padding: var(--spacing-xs) 0;
+  display: block;
+}
+
+.nav-link:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav-link.active {
+  color: #fff;
+  font-weight: 600;
+}
+
+/* Navbar toggler (hamburger) */
+.nav-toggler {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.nav-toggler span {
+  display: block;
+  width: 25px;
+  height: 2px;
+  background: #fff;
+  border-radius: 2px;
+  transition: transform 0.2s;
+}
+
+@media (min-width: 768px) {
+  .nav-toggler {
+    display: none;
+  }
+
+  .nav-links {
+    display: flex;
+    flex-direction: row;
+    position: static;
+    background: none;
+    padding: 0;
+    gap: var(--spacing-md);
+  }
+
+  .nav-link {
+    padding: 0;
+  }
+}
+```
+
+- [ ] **Step 2: Rewrite navbar in `header.html`**
+
+Replace the `navigate` fragment with:
+```html
+<th:block th:fragment="navigate">
+  <nav class="navbar">
+    <a class="navbar-brand" th:href="@{/}">Spring Boot</a>
+    <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden>
+    <label for="nav-toggle" class="nav-toggler">
+      <span></span><span></span><span></span>
+    </label>
+    <ul class="nav-links">
+      <li><a class="nav-link active" th:href="@{/}">Home</a></li>
+      <li><a class="nav-link" th:href="@{/news}">News</a></li>
+    </ul>
+  </nav>
+</th:block>
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `./gradlew build`
+
+---
+
+### Task 3: Add grid, cards, utilities to CSS; update news page
+
+**Files:**
+- Modify: `src/main/resources/static/css/style.css` (append remaining CSS)
+- Modify: `src/main/resources/templates/news.html` (replace all Bootstrap classes)
+- Modify: `src/main/resources/templates/welcome.html`
+
+- [ ] **Step 1: Add container, grid, card, and utility CSS**
+
+Append to `style.css`:
+```css
+/* Container */
+.container,
+.container-fluid {
+  padding: 0 var(--spacing-md);
+  margin-inline: auto;
+}
+
+.container {
+  max-width: var(--container-max-width);
+}
+
+/* News grid */
+.news-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+/* News card */
+.news-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--color-card-bg);
+}
+
+.news-card__image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.news-card__body {
+  padding: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  flex: 1;
+}
+
+.news-card__meta {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
+.news-card__title {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.news-card__title a {
+  color: var(--color-dark);
+  text-decoration: none;
+}
+
+.news-card__title a:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.news-card__text {
+  flex: 1;
+  color: var(--color-dark);
+}
+
+/* Utilities */
+.mb-1 { margin-bottom: var(--spacing-xs); }
+.mb-3 { margin-bottom: var(--spacing-md); }
+.mb-4 { margin-bottom: var(--spacing-lg); }
+.mb-0 { margin-bottom: 0; }
+.py-5 { padding-block: var(--spacing-xl); }
+.text-muted { color: var(--color-muted); }
+.text-secondary { color: var(--color-secondary-text); }
+.text-dark { color: var(--color-dark); }
+.text-center { text-align: center; }
+.small { font-size: var(--font-size-sm); }
+.d-flex { display: flex; }
+.flex-column { flex-direction: column; }
+.flex-grow-1 { flex-grow: 1; }
+
+/* Empty state */
+.empty-state-icon {
+  color: var(--color-muted);
+}
+```
+
+- [ ] **Step 2: Rewrite `news.html`**
+
+Replace entire file content with:
+```html
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>News - Springmvcdemo</title>
+    <div th:replace="~{fragments/header :: header-css}"></div>
+</head>
+<body>
+<div th:replace="~{fragments/header :: navigate}"></div>
+<div class="container">
+    <h1 class="mb-4">News:</h1>
+
+    <div th:if="${#lists.isEmpty(newsList)}" class="text-center py-5">
+        <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="empty-state-icon mb-3" viewBox="0 0 16 16">
+            <path d="M0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v10.528c0 .3-.05.654-.238.972h.738a.5.5 0 0 0 .5-.5v-9a.5.5 0 0 1 1 0v9a1.5 1.5 0 0 1-1.5 1.5H1.497A1.497 1.497 0 0 1 0 13.5v-11zM12 14c.37 0 .654-.05.972-.238A.5.5 0 0 0 13 13.5v-11A.5.5 0 0 0 12.5 2h-11A.5.5 0 0 0 1 2.5v11c0 .37.05.654.238.972A.5.5 0 0 0 1.5 14h11z"/>
+            <path d="M2.5 3h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1 0-1zm0 2h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1 0-1zm0 2h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1 0-1zm4.5-1a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H7.5a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H7.5a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H7.5a.5.5 0 0 1-.5-.5z"/>
+        </svg>
+        <h3 class="text-muted">No news available</h3>
+        <p class="text-secondary">Try again later or check your API configuration</p>
+    </div>
+
+    <div class="news-grid" th:unless="${#lists.isEmpty(newsList)}">
+        <div th:each="article : ${newsList}" class="news-card">
+            <img th:if="${article.urlToImage != null}"
+                 th:src="${article.urlToImage}" class="news-card__image" alt="News image">
+            <div class="news-card__body">
+                <p class="news-card__meta"
+                   th:text="${article.publishedAt != null ? #temporals.format(article.publishedAt, 'dd-MM-yyyy HH:mm') : 'N/A'}"></p>
+                <h5 class="news-card__title">
+                    <a th:href="${article.url}" target="_blank" rel="noopener noreferrer"
+                       th:text="${article.title}"></a>
+                </h5>
+                <p class="news-card__text" th:text="${article.description ?: 'No description'}"></p>
+                <p class="news-card__meta"
+                   th:text="'By ' + ${article.author ?: 'Unknown'}"></p>
+            </div>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>
+```
+
+- [ ] **Step 3: Update `welcome.html`** — change `container-fluid` to `container-fluid` (already supported in our CSS)
+
+- [ ] **Step 4: Verify build**
+
+Run: `./gradlew build`
+
+---
+
+### Task 4: Test and verify
+
+- [ ] **Step 1: Run tests**
+
+Run: `./gradlew test`
+
+- [ ] **Step 2: Run app and check pages load**
+
+Run: `./gradlew bootRun`
+Visit: `http://localhost:8080/` and `http://localhost:8080/news`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "feat: replace bootstrap with custom css"
+```

--- a/docs/superpowers/specs/2026-05-22-bootstrap-to-native-css-design.md
+++ b/docs/superpowers/specs/2026-05-22-bootstrap-to-native-css-design.md
@@ -1,0 +1,51 @@
+# Bootstrap → Native CSS Migration — Design Spec
+
+## Scope
+Удалить Bootstrap 5.3.3 (WebJars), заменить кастомным CSS на CSS-переменных. 3 Thymeleaf-шаблона, ~10 CSS-переменных, ~100-150 строк CSS.
+
+## Design Tokens (`:root`)
+- **Colors:** `--color-primary: #0d6efd`, `--color-secondary: #20c997`, `--color-dark: #212529`, `--color-muted: #6c757d`, `--color-body-bg`, `--color-card-bg`
+- **Gradient:** `--navbar-gradient: linear-gradient(90deg, #0d6efd, #20c997)`
+- **Spacing:** `--spacing-xs` (0.25rem), `--spacing-sm` (0.5), `--spacing-md` (1), `--spacing-lg` (1.5), `--spacing-xl` (3)
+- **Typography:** `--font-size-sm: 0.875rem`, `--font-size-base: 1rem`
+- **Layout:** `--radius: 0.375rem`, `--container-max-width: 1140px`, `--breakpoint-md: 768px`
+
+## Components
+
+### Navbar
+- `position: sticky; top: 0` + gradient background
+- Flexbox: brand left, toggler right (mobile), links right (desktop)
+- **Mobile collapse:** Checkbox hack (`#nav-toggle:checked ~ .nav-links`)
+- Toggler: 3 `<span>` полоски, `display: none` на `md+`
+- `.nav-links`: `display: none` на mobile, `display: flex` на `md+`
+- Активный пункт: `.nav-link.active` с `font-weight: 600`
+
+### Grid
+- `container`: `max-width: var(--container-max-width); margin-inline: auto; padding: 0 var(--spacing-md)`
+- `container-fluid`: `padding: 0 var(--spacing-md)` (без max-width)
+- `news-grid`: `display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: var(--spacing-lg)`
+
+### Cards (BEM)
+- `.news-card`: border, radius, overflow hidden, flex column, bg white
+- `.news-card__image`: `height: 200px; object-fit: cover; width: 100%`
+- `.news-card__body`: padding, flex column, gap between elements
+- `.news-card__title`: link `text-decoration: none; color: var(--color-dark)`
+- `.news-card__meta`: `font-size: var(--font-size-sm); color: var(--color-muted)`
+
+### Utilities (только используемые)
+- **Spacing:** `.mb-1/3/4/0`, `.py-5`
+- **Text:** `.text-muted`, `.text-secondary`, `.text-dark`, `.text-center`, `.small`
+- **Flex:** `.d-flex`, `.flex-column`, `.flex-grow-1`
+
+## Empty State
+- Inline SVG: убрать бесполезный класс `.bi-newspaper`, заменить на `.empty-state-icon`
+
+## Files
+
+| Action | File |
+|---|---|
+| **Create** | `src/main/resources/static/css/style.css` |
+| **Edit** | `src/main/resources/templates/fragments/header.html` |
+| **Edit** | `src/main/resources/templates/news.html` |
+| **Edit** | `src/main/resources/templates/welcome.html` |
+| **Edit** | `build.gradle.kts` — удалить bootstrap + webjars-locator |

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,0 +1,21 @@
+:root {
+  --color-primary: #0d6efd;
+  --color-secondary: #20c997;
+  --color-dark: #212529;
+  --color-muted: #6c757d;
+  --color-secondary-text: #6c757d;
+  --color-body-bg: #fff;
+  --color-card-bg: #fff;
+  --color-border: rgba(0, 0, 0, 0.125);
+  --navbar-gradient: linear-gradient(90deg, #0d6efd, #20c997);
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 3rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --radius: 0.375rem;
+  --container-max-width: 1140px;
+  --breakpoint-md: 768px;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -151,3 +151,90 @@ a:hover {
     padding: 0;
   }
 }
+
+/* Container */
+.container,
+.container-fluid {
+  padding: 0 var(--spacing-md);
+  margin-inline: auto;
+}
+
+.container {
+  max-width: var(--container-max-width);
+}
+
+/* News grid */
+.news-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+/* News card */
+.news-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--color-card-bg);
+}
+
+.news-card__image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.news-card__body {
+  padding: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  flex: 1;
+}
+
+.news-card__meta {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
+.news-card__title {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.news-card__title a {
+  color: var(--color-dark);
+  text-decoration: none;
+}
+
+.news-card__title a:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.news-card__text {
+  flex: 1;
+  color: var(--color-dark);
+}
+
+/* Utilities */
+.mb-1 { margin-bottom: var(--spacing-xs); }
+.mb-3 { margin-bottom: var(--spacing-md); }
+.mb-4 { margin-bottom: var(--spacing-lg); }
+.mb-0 { margin-bottom: 0; }
+.py-5 { padding-block: var(--spacing-xl); }
+.text-muted { color: var(--color-muted); }
+.text-secondary { color: var(--color-secondary-text); }
+.text-dark { color: var(--color-dark); }
+.text-center { text-align: center; }
+.small { font-size: var(--font-size-sm); }
+.d-flex { display: flex; }
+.flex-column { flex-direction: column; }
+.flex-grow-1 { flex-grow: 1; }
+
+/* Empty state */
+.empty-state-icon {
+  color: var(--color-muted);
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -80,6 +80,14 @@ a:hover {
   padding: var(--spacing-sm) var(--spacing-md);
 }
 
+.nav-toggle {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
 .nav-toggle:checked ~ .nav-links {
   display: flex;
 }
@@ -99,6 +107,12 @@ a:hover {
 .nav-link.active {
   color: #fff;
   font-weight: 600;
+}
+
+.nav-link:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 /* Navbar toggler (hamburger) */

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -68,7 +68,6 @@ a:hover {
 .nav-links {
   list-style: none;
   margin: 0;
-  padding: 0;
   display: none;
   flex-direction: column;
   gap: var(--spacing-xs);
@@ -83,9 +82,13 @@ a:hover {
 .nav-toggle {
   position: absolute;
   opacity: 0;
-  width: 0;
-  height: 0;
-  pointer-events: none;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .nav-toggle:checked ~ .nav-links {
@@ -131,6 +134,12 @@ a:hover {
   background: #fff;
   border-radius: 2px;
   transition: transform 0.2s;
+}
+
+.nav-toggler:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 @media (min-width: 768px) {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -19,3 +19,121 @@
   --container-max-width: 1140px;
   --breakpoint-md: 768px;
 }
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: var(--font-size-base);
+  color: var(--color-dark);
+  background: var(--color-body-bg);
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Navbar */
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--navbar-gradient);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.navbar-brand {
+  color: #fff;
+  font-size: var(--spacing-lg);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.navbar-brand:hover {
+  text-decoration: none;
+  opacity: 0.9;
+}
+
+.nav-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: none;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--navbar-gradient);
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.nav-toggle:checked ~ .nav-links {
+  display: flex;
+}
+
+.nav-link {
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  padding: var(--spacing-xs) 0;
+  display: block;
+}
+
+.nav-link:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav-link.active {
+  color: #fff;
+  font-weight: 600;
+}
+
+/* Navbar toggler (hamburger) */
+.nav-toggler {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.nav-toggler span {
+  display: block;
+  width: 25px;
+  height: 2px;
+  background: #fff;
+  border-radius: 2px;
+  transition: transform 0.2s;
+}
+
+@media (min-width: 768px) {
+  .nav-toggler {
+    display: none;
+  }
+
+  .nav-links {
+    display: flex;
+    flex-direction: row;
+    position: static;
+    background: none;
+    padding: 0;
+    gap: var(--spacing-md);
+  }
+
+  .nav-link {
+    padding: 0;
+  }
+}

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -6,12 +6,12 @@
 <th:block th:fragment="navigate">
   <nav class="navbar">
     <a class="navbar-brand" th:href="@{/}">Spring Boot</a>
-    <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden>
+    <input type="checkbox" id="nav-toggle" class="nav-toggle">
     <label for="nav-toggle" class="nav-toggler">
       <span></span><span></span><span></span>
     </label>
     <ul class="nav-links">
-      <li><a class="nav-link active" th:href="@{/}">Home</a></li>
+      <li><a class="nav-link active" aria-current="page" th:href="@{/}">Home</a></li>
       <li><a class="nav-link" th:href="@{/news}">News</a></li>
     </ul>
   </nav>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -4,24 +4,16 @@
     <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}" />
 </th:block>
 <th:block th:fragment="navigate">
-    <!-- this is header -->
-    <nav class="navbar sticky-top navbar-dark navbar-expand-lg mb-4" style="background: linear-gradient(90deg, #0d6efd, #20c997);">
-        <a class="navbar-brand" th:href="@{/}">Spring Boot</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
-                aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav me-auto">
-                <li class="nav-item active">
-                    <a class="nav-link" th:href="@{/}">Home</a>
-                </li>
-                <li class="nav-item ">
-                    <a class="nav-link" th:href="@{/news}">News</a>
-                </li>
-            </ul>
-        </div>
-    </nav>
+  <nav class="navbar">
+    <a class="navbar-brand" th:href="@{/}">Spring Boot</a>
+    <input type="checkbox" id="nav-toggle" class="nav-toggle" hidden>
+    <label for="nav-toggle" class="nav-toggler">
+      <span></span><span></span><span></span>
+    </label>
+    <ul class="nav-links">
+      <li><a class="nav-link active" th:href="@{/}">Home</a></li>
+      <li><a class="nav-link" th:href="@{/news}">News</a></li>
+    </ul>
+  </nav>
 </th:block>
 </html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,10 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <th:block th:fragment="header-css">
-    <!-- this is header-css -->
-    <link rel="stylesheet" type="text/css" th:href="@{/webjars/bootstrap/dist/css/bootstrap.min.css}" />
-    <script type="text/javascript"
-            src="webjars/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}" />
 </th:block>
 <th:block th:fragment="navigate">
     <!-- this is header -->

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -7,7 +7,8 @@
   <nav class="navbar">
     <a class="navbar-brand" th:href="@{/}">Spring Boot</a>
     <input type="checkbox" id="nav-toggle" class="nav-toggle">
-    <label for="nav-toggle" class="nav-toggler">
+    <label for="nav-toggle" class="nav-toggler" tabindex="0" role="button"
+           onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();document.getElementById('nav-toggle').checked=!document.getElementById('nav-toggle').checked}">
       <span></span><span></span><span></span>
     </label>
     <ul class="nav-links">

--- a/src/main/resources/templates/news.html
+++ b/src/main/resources/templates/news.html
@@ -11,7 +11,7 @@
 
     <!-- Empty state -->
     <div th:if="${#lists.isEmpty(newsList)}" class="text-center py-5">
-        <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="bi bi-newspaper text-muted mb-3" viewBox="0 0 16 16">
+        <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="empty-state-icon mb-3" viewBox="0 0 16 16">
             <path d="M0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v10.528c0 .3-.05.654-.238.972h.738a.5.5 0 0 0 .5-.5v-9a.5.5 0 0 1 1 0v9a1.5 1.5 0 0 1-1.5 1.5H1.497A1.497 1.497 0 0 1 0 13.5v-11zM12 14c.37 0 .654-.05.972-.238A.5.5 0 0 0 13 13.5v-11A.5.5 0 0 0 12.5 2h-11A.5.5 0 0 0 1 2.5v11c0 .37.05.654.238.972A.5.5 0 0 0 1.5 14h11z"/>
             <path d="M2.5 3h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1 0-1zm0 2h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1 0-1zm0 2h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1 0-1zm4.5-1a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H7.5a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H7.5a.5.5 0 0 1-.5-.5zm0 2a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1H7.5a.5.5 0 0 1-.5-.5z"/>
         </svg>
@@ -20,23 +20,20 @@
     </div>
 
     <!-- News cards -->
-    <div class="row" th:unless="${#lists.isEmpty(newsList)}">
-        <div th:each="article : ${newsList}" class="col-md-6 col-lg-4 mb-4">
-            <div class="card h-100">
-                <img th:if="${article.urlToImage != null}"
-                     th:src="${article.urlToImage}" class="card-img-top" alt="News image"
-                     style="height: 200px; object-fit: cover;">
-                <div class="card-body d-flex flex-column">
-                    <p class="text-muted small mb-1"
-                       th:text="${article.publishedAt != null ? #temporals.format(article.publishedAt, 'dd-MM-yyyy HH:mm') : 'N/A'}"></p>
-                    <h5 class="card-title">
-                        <a th:href="${article.url}" target="_blank" rel="noopener noreferrer"
-                           th:text="${article.title}" class="text-decoration-none text-dark"></a>
-                    </h5>
-                    <p class="card-text flex-grow-1" th:text="${article.description ?: 'No description'}"></p>
-                    <p class="card-text text-muted small mb-0"
-                       th:text="'By ' + ${article.author ?: 'Unknown'}"></p>
-                </div>
+    <div class="news-grid" th:unless="${#lists.isEmpty(newsList)}">
+        <div th:each="article : ${newsList}" class="news-card">
+            <img th:if="${article.urlToImage != null}"
+                 th:src="${article.urlToImage}" class="news-card__image" alt="News image">
+            <div class="news-card__body">
+                <p class="news-card__meta"
+                   th:text="${article.publishedAt != null ? #temporals.format(article.publishedAt, 'dd-MM-yyyy HH:mm') : 'N/A'}"></p>
+                <h5 class="news-card__title">
+                    <a th:href="${article.url}" target="_blank" rel="noopener noreferrer"
+                       th:text="${article.title}"></a>
+                </h5>
+                <p class="news-card__text" th:text="${article.description ?: 'No description'}"></p>
+                <p class="news-card__meta"
+                   th:text="'By ' + ${article.author ?: 'Unknown'}"></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Что сделано

- 604a82a — создан style.css с design токенами, удалены bootstrap webjars
- 59ec06e — переписана навигация на чистый CSS (checkbox hack)
- 11f03f3 — исправлены accessibility issues (keyboard nav, focus, aria)
- a82c029 — добавлены grid, cards, utilities в CSS; обновлена страница news
- 36f3fd0 — bootstrap полностью заменён на кастомные стили
- b43e4c9 — финальные правки по ревью (a11y, focus, cleanup)